### PR TITLE
Almost worked the first time.  The extended LIBPATH support allowed d…

### DIFF
--- a/modules/core/mod_so.c
+++ b/modules/core/mod_so.c
@@ -154,7 +154,7 @@ static int update_beginlibpath(cmd_parms *cmd, const char *fullname)
     char dir[CCHMAXPATH];
     char *p;
     APIRET apiret;
-    char *suffix = ";%%BEGINLIBPATH%%";
+    char *suffix = ";%BEGINLIBPATH%";
 
     strncpy(dir, fullname, CCHMAXPATH);
     dir[CCHMAXPATH - 1] = 0;
@@ -231,7 +231,7 @@ static const char *dso_load(cmd_parms *cmd, apr_dso_handle_t **modhandlep,
             return NULL;
     }
 
-#if __OS2__                             // 2022-05-09 SHL
+#ifdef __OS2__                          // 2022-05-09 SHL
     if (!retry && fullname) {
         int rv;
         /* Assume load failed because some required module was not


### PR DESCRIPTION
…av_fs.dll to be loaded before dav.dll in httpd.conf.

However, not all of the testcase code made it into mod_so.c correctly with the result that the pre-existing reference to the php extensions directory was lost when the extended LIBPATH was updated and modphp7 failed to load.

This commit corrects the mod_so.c sources to avoid this failure.